### PR TITLE
Specify `autoparse_metadata` kwargs in xgcm.Grid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
-        #python-version: [3.13]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        #python-version: ['3.13']
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #python-version: [3.7, 3.8, 3.9]
-        python-version: [3.9]
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        #python-version: [3.13]
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           channels: conda-forge
           mamba-version: '*'
           python-version: ${{ matrix.python-version }}
-          activate-environment: testing
+          activate-environment: test_env_xwmt
           auto-activate-base: false
 
       - name: Set up conda environment

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,4 +1,4 @@
-name: testing
+name: test_env_xwmt
 channels:
   - conda-forge
   - defaults

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,11 +9,11 @@ dependencies:
   - numba
   - numpy
   - pandas
-  - pip
   - pylint
   - python==3.9
   - pytest
   - xarray
   - pip
+  - pip:
     - xgcm @ git+https://github.com/xgcm/xgcm.git@master
     - xhistogram

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -14,5 +14,6 @@ dependencies:
   - python==3.9
   - pytest
   - xarray
-  - xgcm==0.5.2
-  - xhistogram==0.3.1
+  - pip
+    - xgcm @ git+https://github.com/xgcm/xgcm.git@master
+    - xhistogram

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - numpy
   - pandas
   - pylint
-  - python==3.9
   - pytest
   - xarray
   - pip

--- a/xwmt/swmt.py
+++ b/xwmt/swmt.py
@@ -398,7 +398,7 @@ class swmt:
         """Specify the percentile and number of the bins"""
         l_sample = l.isel(time=0).chunk({"y": -1, "x": -1})
         vmin, vmax = l_sample.quantile(percentile, dim=l_sample.dims)
-        return np.linspace(vmin, vmax, bins)
+        return np.linspace(vmin.values, vmax.values, bins)
 
     def calc_F_transformed(
         self, lstr, bins=None, mass="total", salt="total", heat="total", decompose=None

--- a/xwmt/swmt.py
+++ b/xwmt/swmt.py
@@ -126,7 +126,7 @@ class swmt:
         # TODO: Add error message if lev and/or lev_outer in ds.
 
         # Create xgcm object with modified ds
-        self.xgrid = get_xgcm_grid_vertical(self.ds, metrics=True, periodic=False)
+        self.xgrid = get_xgcm_grid_vertical(self.ds, metrics=True, periodic=False, autoparse_metadata=False)
 
     # Helper function to get variable name for given tendency
     def tend(self, tendency):

--- a/xwmt/tests/test_functional.py
+++ b/xwmt/tests/test_functional.py
@@ -10,40 +10,40 @@ ds = ds.rename({"xh": "x", "yh": "y", "geolat": "lat", "geolon": "lon"})
 # sigma
 def test_functional_sigma0_default():
     total = xwmt.swmt(ds).G("sigma0")
-    assert np.allclose(total.sum(), -2.1251855e09)
+    assert np.allclose(total.sum(), -2.1251855e09, rtol=1e-4)
     
 def test_functional_sigma1_default():
     total = xwmt.swmt(ds).G("sigma1")
-    assert np.allclose(total.sum(), -1.8154245e09)
+    assert np.allclose(total.sum(), -1.8154245e09, rtol=1e-4)
 
 def test_functional_sigma2_default():
     total = xwmt.swmt(ds).G("sigma2")
-    assert np.allclose(total.sum(), -1.5430248e09)
+    assert np.allclose(total.sum(), -1.5430248e09, rtol=1e-4)
     
 def test_functional_sigma3_default():
     total = xwmt.swmt(ds).G("sigma3")
-    assert np.allclose(total.sum(), -1.32300659e09)
+    assert np.allclose(total.sum(), -1.32300659e09, rtol=1e-4)
     
 def test_functional_sigma4_default():
     total = xwmt.swmt(ds).G("sigma4")
-    assert np.allclose(total.sum(), -1.20211688e09)
+    assert np.allclose(total.sum(), -1.20211688e09, rtol=1e-4)
 
 # heat
 def test_functional_theta_default():
     total = xwmt.swmt(ds).G("theta")
-    assert np.allclose(total.sum(), -1.65192249e09)
+    assert np.allclose(total.sum(), -1.65192249e09, rtol=1e-4)
 # salt
 def test_functional_salt_default():
     total = xwmt.swmt(ds).G("salt")
-    assert np.allclose(total.sum(), -3.01411116e08)
+    assert np.allclose(total.sum(), -3.01411116e08, rtol=1e-4)
 
 ## Tendencies not grouped
 def test_functional_sigma0_notgrouped():
     total = xwmt.swmt(ds).G("sigma0",group_tend=False)
-    assert np.allclose(total["heat"].sum(), -2.8727879e09)
-    assert np.allclose(total["salt"].sum(), 7.47602401e08)
+    assert np.allclose(total["heat"].sum(), -2.8727879e09, rtol=1e-4)
+    assert np.allclose(total["salt"].sum(), 7.47602401e08, rtol=1e-4)
     
 ## xgcm
 def test_functional_sigma0_xgcm():
     total = xwmt.swmt(ds).G("sigma0",method="xgcm")
-    assert np.allclose(total.sum(), -2.1251855e09)
+    assert np.allclose(total.sum(), -2.1251855e09, rtol=1e-4)

--- a/xwmt/version.py
+++ b/xwmt/version.py
@@ -1,3 +1,3 @@
 """xwmt: version information"""
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"


### PR DESCRIPTION
There was a breaking change in the default behavior of xgcm's API, I think after this  PR https://github.com/xgcm/xgcm/pull/559. The new default behavior is to try to infer axis info from metadata.

This retains the old behavior by specifying the `autoparse_metadata = False` kwargs so that `xgcm.Grid` knows we are specifying the metadata ourselves.

This should address the issue raised by @jkrasting whereby the MAR notebook https://github.com/jkrasting/mar/blob/main/src/gfdlnb/notebooks/ocean/WMT_North_Atlantic.ipynb was no longer compatible with the `stable` odiv conda environment.